### PR TITLE
We don't run jobs in beta

### DIFF
--- a/config/deploy.beta.yml
+++ b/config/deploy.beta.yml
@@ -5,11 +5,9 @@ servers:
       - fizzy-beta-app-101.df-iad-int.37signals.com: df_iad
     labels:
       otel_scrape_enabled: true
-  jobs:
-    hosts:
-      - fizzy-beta-app-01.sc-chi-int.37signals.com: sc_chi
-    labels:
-      otel_scrape_enabled: true
+
+# we don't run the jobs role in beta
+allow_empty_roles: true
 
 proxy:
   ssl: false


### PR DESCRIPTION
I think this was hallucinated in the original commit. This is causing racing between beta and prod, and as a result beta was attempting to send emails for production.

Fortunately, smtp is not configured in beta and prevented bad emails from going out. 😅

@jorgemanrubia 